### PR TITLE
Adiciona lista padrão

### DIFF
--- a/Lista_de_Acolitos.js
+++ b/Lista_de_Acolitos.js
@@ -1,0 +1,1 @@
+nome = ["Danilo","Mario","Fer","Italo","Paulo pano de Prato"]

--- a/gerenciador.py
+++ b/gerenciador.py
@@ -26,9 +26,12 @@ if program_mode == 0:
                 break
         else: 
             acolitos.append(nome)
+    try:
+        os.remove("Lista_de_Acolitos.js")
+    except:
+        pass
 #Modo editor
 elif program_mode == 1:
-    #config.read_file(open("lista-de-acolitos.dat"))
     config.read("lista-de-acolitos.dat")
     acolitos = config.get("acolitos", "nomes").split("+")
     while True:


### PR DESCRIPTION
Adiciona uma lista padrão que serve para o programa principal funcionar como demonstração.
Adicionou comandos no gerenciador de lista para iniciar no modo criador e substituir a lista padrão
Removeu uma linha comentada que não tinha propósito.